### PR TITLE
Moved ENV var declaration step before

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,10 +35,10 @@ jobs:
             ghcr.io/los-dos-coders/letsplay-backend
       - name: Add Digital Ocean Token to Env Var
         run: export DNS_DIGITALOCEAN_TOKEN=${{ secrets.DNS_DIGITALOCEAN_TOKEN }}
+      - name: Set environment to production
+        run: export ENV="prod"
       - name: Build Docker Image
         run: docker-compose build
-      - name: Set environment to production
-        run: export env="prod"
       - name: Push the Docker Images to the repo
         run: docker-compose push
       - name: Install SSH Key


### PR DESCRIPTION
Moved declaring prod ENV to be before the docker build step. Otherwise, only a self-signed cert will be used on server, not a legit one from Let's Encrypt